### PR TITLE
Add secondary messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For retrieving promotions for zero, one or more products, use the specific Place
                     let imageBadge = content.getImageBadge()
                     let textBadge = content.getTextBadge()
                                
-                    let conf = p.content?.contentConfig
+                    let conf = p.content?.contentConfig()
                     switch conf {
                     case let conf as ImageBadge:
                         let image = conf.image
@@ -127,6 +127,9 @@ For retrieving promotions for zero, one or more products, use the specific Place
                         let fontColor = conf.fontColor ?? ""
                         let background = conf.backgroundColor ?? ""
                         let borderColor = conf.borderColor ?? ""
+                    case let conf as SecondaryMessaging:
+                        let text = conf.text
+                        let fontColor = conf.fontColor ?? ""
                     default:
                         //
                     }
@@ -201,6 +204,12 @@ For retrieving promotions for zero, one or more products, use the specific Place
 | altText | String? | Alternate text |
 
 
+### Secondary Messaging
+
+| Name            | Type        | Description               |
+|-----------------|-------------|---------------------------|
+| text            | String      | Text message              |
+| fontColor       | String      | Font color                |
 
 ## Samples
 

--- a/Sources/Crobox/domain/model/Components.swift
+++ b/Sources/Crobox/domain/model/Components.swift
@@ -1,12 +1,6 @@
 import Foundation
 
-public enum PromotionContentType {
-    case image
-    case text
-}
-
 public protocol PromotionContentConfig {
-    var contentType: PromotionContentType { get }
     var name: String { get }
 }
 
@@ -14,7 +8,6 @@ public struct ImageBadge : PromotionContentConfig {
     public let image: String
     public let altText: String?
     public let name: String
-    public let contentType: PromotionContentType = .image
 }
 
 public struct TextBadge : PromotionContentConfig {
@@ -23,5 +16,10 @@ public struct TextBadge : PromotionContentConfig {
     public let backgroundColor: String?
     public let borderColor: String?
     public let name: String
-    public let contentType: PromotionContentType = .text
+}
+
+public struct SecondaryMessaging : PromotionContentConfig {
+    public let text: String
+    public let fontColor: String?
+    public let name: String
 }

--- a/Sources/Crobox/domain/model/PromotionContent.swift
+++ b/Sources/Crobox/domain/model/PromotionContent.swift
@@ -14,8 +14,8 @@ public class PromotionContent: NSObject {
      *
      * Example:
      * Map(
-     *   "Text1_text" : "Best Seller",
-     *   "Text1_color" : "#0e1111"
+     *   "text" : "Best Seller",
+     *   "textColor" : "#0e1111"
      *  )
      */
     public var config: [String: String] = [:]
@@ -30,7 +30,6 @@ public class PromotionContent: NSObject {
                 self.config[key] = stringValue
             }
         }
-        
     }
     
     func getValue(_ key: String) -> String? {
@@ -41,13 +40,17 @@ public class PromotionContent: NSObject {
         return config[key] ?? defaultValue
     }
     
-    public lazy var contentConfig: PromotionContentConfig? = if let image = getValue("image") {
-        getImageBadge()
-    } else {
-        getTextBadge()
+    public func contentConfig() -> PromotionContentConfig? {
+        if (componentName == "mob-app-image-badge.tsx") {
+            return getImageBadge()
+        } else if (componentName == "mob-app-secondary-messaging.tsx") {
+            return getSecondaryMessaging()
+        } else if (componentName == "mob-app-text-badge.tsx") {
+            return getTextBadge()
+        } else {
+            return nil
+        }
     }
-    
-    public lazy var promotionType: PromotionContentType? = contentConfig?.contentType
     
     /// Returns image badge configuration with pre-designed configuration keys
     public func getImageBadge() -> ImageBadge? {
@@ -66,4 +69,14 @@ public class PromotionContent: NSObject {
             return nil
         }
     }
+    
+    /// Returns secondary messaging configuration with pre-designed configuration keys
+    public func getSecondaryMessaging() -> SecondaryMessaging? {
+        if let text = getValue("text") {
+            return SecondaryMessaging(text: text, fontColor: getValue("fontColor"), name: componentName)
+        } else {
+            return nil
+        }
+    }
+    
 }

--- a/Tests/CroboxTests/PromotionFailureTests.swift
+++ b/Tests/CroboxTests/PromotionFailureTests.swift
@@ -3,15 +3,19 @@ import XCTest
 
 final class PromotionFailureTests: XCTestCase {
     
+    override func tearDown() async throws {
+        try await Task.sleep(for: .milliseconds(2000), tolerance: .seconds(0.5))
+    }
+    
     func testPromotionsError() async throws {
-        let overviewPageParams = RequestQueryParams.init(viewId: UUID(), pageType: .PageOverview, customProperties: ["test":"async"])
+        let overviewPageParams = RequestQueryParams.init(viewId: UUID(), pageType: .PageOverview, customProperties: ["test":"failure"])
         let brokenConfig = CroboxConfig(containerId: "9999", visitorId: UUID.init(), localeCode: .en_US)
         Crobox.shared.initConfig(config: brokenConfig)
         Crobox.shared.isDebug = true
         
-        let result = await Crobox.shared.promotions(placeholderId: "30",
+        let result = await Crobox.shared.promotions(placeholderId: "1",
                                                     queryParams: overviewPageParams,
-                                                    productIds: ["29883481", "04133050", "3A626400"])
+                                                    productIds: ["1", "2", "3"])
         switch result {
         case .success(_):
             XCTFail("\(result)")

--- a/Tests/CroboxTests/PromotionTests.swift
+++ b/Tests/CroboxTests/PromotionTests.swift
@@ -33,28 +33,62 @@ final class PromotionTests: XCTestCase {
         let detailPageParams = RequestQueryParams.init(viewId: UUID(), pageType: .PageDetail)
         let result = await Crobox.shared.promotions(placeholderId: "1",
                                                     queryParams: detailPageParams,
-                                                    productIds: ["29883481"])
+                                                    productIds: ["1"])
         switch result {
         case let .success(response):
             XCTAssertNotNil(response.context.sessionId)
             XCTAssertEqual(PromotionTests.visitorId, response.context.visitorId)
+            printAll(response)
         case .failure(_):
             XCTFail()
         }
-        
-        func testPromotionsMultiProducts() async throws {
-            let result = await Crobox.shared.promotions(placeholderId: "1",
-                                                        queryParams: overviewPageParams,
-                                                        productIds: ["product1", "product2", "product3", "product4"])
-            switch result {
-            case let .success(response):
-                let context = response.context
-                XCTAssertNotNil(context.sessionId)
-                XCTAssertEqual(PromotionTests.visitorId, context.visitorId)
-            case .failure(_):
-                XCTFail()
-            }
+    }
+    
+    func testPromotionsMultiProducts() async throws {
+        let result = await Crobox.shared.promotions(placeholderId: "1",
+                                                    queryParams: overviewPageParams,
+                                                    productIds: ["product1", "product2", "product3", "product4"])
+        switch result {
+        case let .success(response):
+            printAll(response)
+            let context = response.context
+            XCTAssertNotNil(context.sessionId)
+            XCTAssertEqual(PromotionTests.visitorId, context.visitorId)
+        case .failure(_):
+            XCTFail()
+        }
+    }
+    
+    private func printAll(_ response: PromotionResponse) {
+        let context = response.context
+        let p = context.visitorId
+        print("VisitorId: \(p)")
+        for c in context.campaigns {
+            print("\tCampaign:[Id: \(c.id), Name: \(c.name)]")
+        }
+        print("Promotions: \(response.promotions.count)")
+        for p in response.promotions {
+            print("Id: \(p.id.uuidString)")
+            print("Product: \(p.productId ?? "")")
+            print("Campaign Id: \(p.campaignId)")
+            print("Config: \(p.content?.config ?? [:])")
             
+            let badge = p.content?.contentConfig()
+            switch badge {
+            case let badge as ImageBadge:
+                print("Image: \(badge.image)")
+                print("AltText: \(badge.altText ?? "")")
+            case let badge as TextBadge:
+                print("Text: \(badge.text)")
+                print("FontColor: \(badge.fontColor ?? "")")
+                print("Background: \(badge.backgroundColor ?? "")")
+                print("Border: \(badge.borderColor ?? "")")
+            case let badge as SecondaryMessaging:
+                print("Secondary Text: \(badge.text)")
+                print("Secondary FontColor: \(badge.fontColor ?? "")")
+            default:
+                print("n/a")
+            }
         }
     }
     

--- a/Tests/CroboxTests/domain/model/PromotionResponseTests.swift
+++ b/Tests/CroboxTests/domain/model/PromotionResponseTests.swift
@@ -181,7 +181,7 @@ final class PromotionResponseTests: XCTestCase {
     }
     
     func testPromotionContentAsTextConfig() async throws {
-        let name = "component1.tsx"
+        let name = "mob-app-text-badge.tsx"
         let text = "Best Seller"
         let fontColor = "#ffffff"
         let backgroundColor = "#aaaaaa"
@@ -201,7 +201,7 @@ final class PromotionResponseTests: XCTestCase {
         let json = JSON(parseJSON: jsonStr)
         let promotionContent = PromotionContent(jsonData: json)
         
-        let textBadge = promotionContent.contentConfig
+        let textBadge = promotionContent.contentConfig()
         switch textBadge {
         case let textBadge as TextBadge:
             XCTAssertEqual(name, textBadge.name)
@@ -213,11 +213,10 @@ final class PromotionResponseTests: XCTestCase {
         default:
             XCTFail("Expected text badge")
         }
-        
     }
     
     func testPromotionContentAsImageConfig() async throws {
-        let name = "component1.tsx"
+        let name = "mob-app-image-badge.tsx"
         let image = "//cdn.crobox.io/content/xlrc9t/Image.png"
         let altText = "Image alt text"
         let jsonStr = """
@@ -233,7 +232,7 @@ final class PromotionResponseTests: XCTestCase {
         let json = JSON(parseJSON: jsonStr)
         let promotionContent = PromotionContent(jsonData: json)
         
-        let badge = promotionContent.contentConfig
+        let badge = promotionContent.contentConfig()
         switch badge {
         case let badge as ImageBadge:
             XCTAssertEqual(image, badge.image)
@@ -246,6 +245,33 @@ final class PromotionResponseTests: XCTestCase {
         
     }
     
+    func testPromotionContentAsSecondaryMessaging() async throws {
+        let name = "mob-app-secondary-messaging.tsx"
+        let text = "Best Seller"
+        let fontColor = "#ffffff"
+        let jsonStr = """
+            {
+                "component": "\(name)",
+                "config": {
+                    "text": "\(text)",
+                    "fontColor": "\(fontColor)"
+                }
+            }
+        """.trimmingCharacters(in: .whitespaces)
+        
+        let json = JSON(parseJSON: jsonStr)
+        let promotionContent = PromotionContent(jsonData: json)
+        
+        let config = promotionContent.contentConfig()
+        switch config {
+        case let sm as SecondaryMessaging:
+            XCTAssertEqual(name, sm.name)
+            XCTAssertEqual(text, sm.text)
+            XCTAssertEqual(fontColor, sm.fontColor)
+        default:
+            XCTFail("Expected secondary messaging")
+        }
+    }
     
 }
 

--- a/app/app/ViewController.swift
+++ b/app/app/ViewController.swift
@@ -140,7 +140,8 @@ class ViewController: UIViewController {
             print("Campaign Id: \(p.campaignId)")
             print("Config: \(p.content?.config ?? [:])")
             
-            let badge = p.content?.contentConfig
+            
+            let badge = p.content?.contentConfig()
             switch badge {
             case let badge as ImageBadge:
                 print("Image: \(badge.image)")
@@ -150,10 +151,13 @@ class ViewController: UIViewController {
                 print("FontColor: \(badge.fontColor ?? "")")
                 print("Background: \(badge.backgroundColor ?? "")")
                 print("Border: \(badge.borderColor ?? "")")
+            case let badge as SecondaryMessaging:
+                print("Text: \(badge.text)")
+                print("FontColor: \(badge.fontColor ?? "")")
             default:
                 print("n/a")
             }
-            
+
         }
         
     }


### PR DESCRIPTION
- Introducing `SecondaryMessaging` as the third pre-configured promotion content 
- Dropped `PromotionContentType` as it will lead to conflicts. There is no distinct separation between promotion contets as images vs texts.
- 